### PR TITLE
fix(doc): swagger url fixed

### DIFF
--- a/docs/docs/javascripts/swagger-ui-link.js
+++ b/docs/docs/javascripts/swagger-ui-link.js
@@ -1,12 +1,11 @@
 window.onload = function() {
     const ui = SwaggerUIBundle({
-      url: "http://127.0.0.1:8000/Api/swagger.yaml",
+      url: "/Api/swagger.yaml",
       dom_id: '#swagger-ui',
       presets: [
         SwaggerUIBundle.presets.apis,
         SwaggerUIStandalonePreset
       ]
     })
-  
     window.ui = ui
   }


### PR DESCRIPTION
**Context**
Swagger ui in documentation not showing up cause of bad url request

**Implemented solution**
Change url in `docs/docs/javascripts/swagger-ui-link.js`

*_Issues (closes #83 )_*:
