### PR TITLE
fix(ci): fixed auto-deployment docs on gh-pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,18 +3,17 @@ name: deploy-docs
 
 on:
   push:
+    branches:
+      - master
     paths:
       - "docs"
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
-      - run: pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+          python-version: 3.x
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Context**
Auto-deployment documentation on gh-pages fix

**Implemented solution**
Changing action runner with [mkdocs-material deploy](https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions) action (tab Material for Mkdocs)

*_Issues (closes #90 )_*:
