### PR TITLE
fix(axios): fix axios refresh token expired

### DIFF
--- a/frontend/src/helper/axios.js
+++ b/frontend/src/helper/axios.js
@@ -29,10 +29,18 @@ export default function axiosSetUp() {
       const originalRequest = err.config;
       if (
         err.response.status === 401 &&
-        originalRequest.url.includes("/api/v1/jwt/refresh")
+        originalRequest.url.includes("api/v1/jwt/refresh/")
       ) {
         store.commit("auth/clearUserData");
         router.push("/login");
+        store.commit(
+          "updateAlert",
+          {
+            msg: "Your session has expired please login again.",
+            type: "info",
+          },
+          { root: true }
+        );
         return Promise.reject(err);
       } else if (err.response.status === 401 && !originalRequest._retry) {
         originalRequest._retry = true;


### PR DESCRIPTION
**Context**
Fix of axios interceptor which now redirect user that have an expired token and expired refresh token to login page with message in alert-bar to inform him he need to login again.

**Implemented solution**
Fixed the matching on originalRequest string to intercept error on refresh token endpoint and add a commit to store to handle error display for user.

*_Issues (closes #263 )_*:
